### PR TITLE
[#143] ✨ feat : 카카오 로그인 시 임시 닉네임 발급, 회원가입 닉네임 중복 확인, 닉네임 변경 중복 확인, 회원탈퇴  기능 구현

### DIFF
--- a/src/main/java/com/sparta/eduwithme/common/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/eduwithme/common/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     WRONG_PASSWORD(HttpStatus.BAD_REQUEST, "현재 비밀번호가 틀렸습니다."),
     INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 인증코드입니다."),
     EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "이메일 인증이 완료되지 않았습니다."),
+    NICKNAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 사용 중인 닉네임입니다."),
 
     // photo
     FILE_DIRECTORY_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 디렉토리 생성에 실패했습니다."),

--- a/src/main/java/com/sparta/eduwithme/config/WebSecurityConfig.java
+++ b/src/main/java/com/sparta/eduwithme/config/WebSecurityConfig.java
@@ -120,7 +120,8 @@ public class WebSecurityConfig {
                     "/api/ws/**", // webSocket 프로토콜 => connect
                     "/api/chat/**", // chat
                     "/api/topic/**",
-                    "/api/profiles/**"
+                    "/api/profiles/**",
+                    "/api/users/check-nickname"
                 ).permitAll()
                 .anyRequest().authenticated()
         );

--- a/src/main/java/com/sparta/eduwithme/domain/comment/CommentRepository.java
+++ b/src/main/java/com/sparta/eduwithme/domain/comment/CommentRepository.java
@@ -7,6 +7,7 @@ import com.sparta.eduwithme.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -23,4 +24,12 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
             "JOIN c.user u " +
             "WHERE c.user.id = :userId")
     Page<CommentRoomDto> findCommentsWithRoomAndQuestionByUserId(@Param("userId") Long userId, Pageable pageable);
+
+    @Modifying
+    @Query("DELETE FROM Comment c WHERE c.question.id = :questionId")
+    void deleteAllByQuestionId(Long questionId);
+
+    @Modifying
+    @Query("DELETE FROM Comment c WHERE c.user.id = :userId")
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/sparta/eduwithme/domain/question/entity/Question.java
+++ b/src/main/java/com/sparta/eduwithme/domain/question/entity/Question.java
@@ -46,7 +46,7 @@ public class Question extends TimeStamp {
     @JoinColumn(name = "room_id")
     private Room room;
 
-    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     @JoinColumn(name = "answer_id")
     private Answer answer;
 

--- a/src/main/java/com/sparta/eduwithme/domain/question/repository/AnswerRepository.java
+++ b/src/main/java/com/sparta/eduwithme/domain/question/repository/AnswerRepository.java
@@ -1,0 +1,12 @@
+package com.sparta.eduwithme.domain.question.repository;
+
+import com.sparta.eduwithme.domain.question.entity.Answer;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+public interface AnswerRepository extends JpaRepository<Answer, Long> {
+    @Modifying
+    @Query("DELETE FROM Answer a WHERE a.question.id = :questionId")
+    void deleteByQuestionId(Long questionId);
+}

--- a/src/main/java/com/sparta/eduwithme/domain/question/repository/LearningStatusRepository.java
+++ b/src/main/java/com/sparta/eduwithme/domain/question/repository/LearningStatusRepository.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -38,4 +39,8 @@ public interface LearningStatusRepository extends JpaRepository<LearningStatus, 
             "JOIN q.room r " +
             "WHERE ls.user.id = :userId AND ls.questionType = :questionType")
     Page<QuestionDto> findQuestionsWithRoomByUserAndQuestionType(@Param("userId") Long userId, @Param("questionType") QuestionType questionType, Pageable pageable);
+
+    @Modifying
+    @Query("DELETE FROM LearningStatus ls WHERE ls.user.id = :userId")
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/sparta/eduwithme/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/com/sparta/eduwithme/domain/question/repository/QuestionRepository.java
@@ -2,6 +2,7 @@ package com.sparta.eduwithme.domain.question.repository;
 
 import com.sparta.eduwithme.domain.question.entity.Question;
 import com.sparta.eduwithme.domain.room.entity.Room;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,4 +18,6 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
 
     @Query("SELECT MAX(q.orderInRoom) FROM Question q WHERE q.room.id = :roomId")
     Long findMaxOrderInRoom(@Param("roomId") Long roomId);
+
+    List<Question> findAllByRoomId(Long roomId);
 }

--- a/src/main/java/com/sparta/eduwithme/domain/room/repository/RoomRepository.java
+++ b/src/main/java/com/sparta/eduwithme/domain/room/repository/RoomRepository.java
@@ -1,6 +1,7 @@
 package com.sparta.eduwithme.domain.room.repository;
 
 import com.sparta.eduwithme.domain.room.entity.Room;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -10,4 +11,5 @@ public interface RoomRepository extends JpaRepository<Room, Long>, RoomRepositor
     Long countByManagerUserId(Long managerUserId);
     Optional<Room> findByIdAndManagerUserId(Long roomId, Long managerUserId);
     Optional<Room> findByIdAndRoomPassword(Long roomId, String roomPassword);
+    List<Room> findAllByManagerUserId(Long userId);
 }

--- a/src/main/java/com/sparta/eduwithme/domain/room/repository/StudentRepository.java
+++ b/src/main/java/com/sparta/eduwithme/domain/room/repository/StudentRepository.java
@@ -18,4 +18,6 @@ public interface StudentRepository extends JpaRepository<Student, Long> {
     @Query("SELECT s FROM Student s LEFT JOIN FETCH s.room r WHERE s.user.id = :userId")
     List<Student> findStudentsWithRoomByUserId(@Param("userId") Long userId);
 
+    void deleteAllByUserId(Long userId);
+
 }

--- a/src/main/java/com/sparta/eduwithme/domain/user/UserRepository.java
+++ b/src/main/java/com/sparta/eduwithme/domain/user/UserRepository.java
@@ -11,4 +11,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByKakaoId(Long kakaoId);
 
     Optional<User> findByNickName(String sender);
+
 }

--- a/src/main/java/com/sparta/eduwithme/domain/user/controller/UserController.java
+++ b/src/main/java/com/sparta/eduwithme/domain/user/controller/UserController.java
@@ -1,19 +1,25 @@
 package com.sparta.eduwithme.domain.user.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.sparta.eduwithme.common.response.StatusCommonResponse;
 import com.sparta.eduwithme.domain.user.service.SocialService;
 import com.sparta.eduwithme.domain.user.service.UserService;
 import com.sparta.eduwithme.domain.user.dto.*;
 import com.sparta.eduwithme.domain.user.entity.User;
+import com.sparta.eduwithme.security.UserDetailsImpl;
 import com.sparta.eduwithme.util.JwtUtil;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -97,6 +103,25 @@ public class UserController {
     public ResponseEntity<String> resetPassword(@RequestBody EmailCheckDto emailCheckDto) {
         userService.resetPasswordWithTempPassword(emailCheckDto.getEmail(), emailCheckDto.getAuthNum());
         return ResponseEntity.ok("임시 비밀번호가 이메일로 전송되었습니다.");
+    }
+
+    @GetMapping("/check-nickname")
+    public ResponseEntity<?> checkNicknameAvailability(@RequestParam String nickname) {
+        boolean isAvailable = userService.isNicknameAvailable(nickname);
+        Map<String, Boolean> response = new HashMap<>();
+        response.put("available", isAvailable);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/delete")
+    public ResponseEntity<?> deleteAccount(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        try {
+            userService.deleteUser(userDetails.getUser().getId());
+            return ResponseEntity.ok().body(new StatusCommonResponse(200, "회원탈퇴가 완료되었습니다."));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new StatusCommonResponse(500, "회원탈퇴 처리 중 오류가 발생했습니다."));
+        }
     }
 
 }

--- a/src/main/java/com/sparta/eduwithme/domain/user/entity/User.java
+++ b/src/main/java/com/sparta/eduwithme/domain/user/entity/User.java
@@ -1,8 +1,10 @@
 package com.sparta.eduwithme.domain.user.entity;
 
 import com.sparta.eduwithme.common.TimeStamp;
+import com.sparta.eduwithme.domain.comment.entity.Comment;
 import com.sparta.eduwithme.domain.question.entity.LearningStatus;
 import com.sparta.eduwithme.domain.question.entity.QuestionType;
+import com.sparta.eduwithme.domain.room.entity.Student;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -85,8 +87,14 @@ public class User extends TimeStamp {
         this.photoUrl = newPhotoUrl;
     }
 
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<LearningStatus> learningStatusList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Student> students = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> comments;
 
     public Long getTotalPoints() {
         return learningStatusList.stream()

--- a/src/main/java/com/sparta/eduwithme/domain/user/service/SocialService.java
+++ b/src/main/java/com/sparta/eduwithme/domain/user/service/SocialService.java
@@ -8,6 +8,7 @@ import com.sparta.eduwithme.domain.user.dto.KakaoUserInfoDto;
 import com.sparta.eduwithme.domain.user.entity.User;
 import com.sparta.eduwithme.util.JwtUtil;
 import java.net.URI;
+import java.util.Random;
 import java.util.UUID;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -162,14 +163,24 @@ public class SocialService {
             } else { // DB에 새로운 유저를 등록해준다.
                 String password = UUID.randomUUID().toString();
                 String encodedPassword = passwordEncoder.encode(password);
-
                 String email = kakaoUserInfo.getEmail();
+                String nickname = generateUniqueNickname();
 
-                kakaoUser = new User(email, encodedPassword, kakaoUserInfo.getNickname(), kakaoId);
+                while (userRepository.findByNickName(nickname).isPresent()) {
+                    nickname = generateUniqueNickname();
+                }
+
+                kakaoUser = new User(email, encodedPassword, nickname, kakaoId);
             }
             userRepository.save(kakaoUser);
         }
         return kakaoUser;
+    }
+
+    private String generateUniqueNickname() {
+        Random random = new Random();
+        int randomNumber = random.nextInt(100000); // 0 to 99999
+        return String.format("Kakao#%05d", randomNumber);
     }
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #143 
> Close #143 

## 📑 작업 내용
> -카카오 로그인 시 임시 닉네임 발급, 회원가입 닉네임 중복 확인, 닉네임 변경 중복 확인, 회원탈퇴  기능 구현

## 💭 리뷰 요구사항
>
